### PR TITLE
min width error, should be max

### DIFF
--- a/src/screen.css
+++ b/src/screen.css
@@ -153,7 +153,7 @@ label {
 /*
   10em, size 6
 */
-@media screen and (min-width: 10em) {
+@media screen and (max-width: 10em) {
     header h1 {
         font-size: 1em;
     }


### PR DESCRIPTION
This was preventing media queries from doing anything. We should still make sure media queries are useful though, as with the new size of the <h1>welcome</h1> in header, the text is now getting larger and then smaller, rather than just progressively smaller.
